### PR TITLE
used mongo objectids instead of uuid

### DIFF
--- a/backend/apps/task/PyObjectId.py
+++ b/backend/apps/task/PyObjectId.py
@@ -1,0 +1,17 @@
+from bson import ObjectId
+
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not ObjectId.is_valid(v):
+            raise ValueError("Invalid objectid")
+        return ObjectId(v)
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        field_schema.update(type="string")

--- a/backend/apps/task/uni_models.py
+++ b/backend/apps/task/uni_models.py
@@ -1,16 +1,20 @@
 from typing import Optional, List
 from pydantic import BaseModel, Field
-import uuid
+from bson import ObjectId
+
+from .PyObjectId import PyObjectId
 
 
 class UniversitySectionModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     section: str = Field(...)
     instructor: str = Field(...)
     slots: List[str] = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "section": "01",
@@ -21,7 +25,7 @@ class UniversitySectionModel(BaseModel):
 
 
 class UniversityLessonModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     code: str = Field(...)
     ects: float = Field(..., ge=0)
@@ -32,6 +36,8 @@ class UniversityLessonModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "ART OF COMPUTING",
@@ -46,7 +52,7 @@ class UniversityLessonModel(BaseModel):
 
 
 class UniversityAPILessonModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     code: str = Field(...)
     ects: float = Field(..., ge=0)
@@ -55,6 +61,8 @@ class UniversityAPILessonModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "ART OF COMPUTING",
@@ -66,12 +74,14 @@ class UniversityAPILessonModel(BaseModel):
 
 
 class UniversitySemesterModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     lessons: List[UniversityAPILessonModel] = []
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "20-21 Spring",
@@ -80,25 +90,29 @@ class UniversitySemesterModel(BaseModel):
 
 
 class CurriculumLessonModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     code: str = Field(...)
     lessonType: str = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {"name": "PHYSICS I", "code": "PHYS101", "lessonType": "science"}
         }
 
 
 class CurriculumSemesterModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     semester: int = Field(..., gt=0, lt=9)
     lessons: List[CurriculumLessonModel] = []
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "semester": 1,
@@ -107,7 +121,7 @@ class CurriculumSemesterModel(BaseModel):
 
 
 class UniversityCurriculumModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     startYear: int = Field(...)
     endYear: int = Field(...)
@@ -115,18 +129,22 @@ class UniversityCurriculumModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {"name": "2016 Later", "startYear": 2016, "endYear": 2100}
         }
 
 
 class UniversityDepartmentModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     curriculums: List[UniversityCurriculumModel] = []
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "COMP",
@@ -135,13 +153,15 @@ class UniversityDepartmentModel(BaseModel):
 
 
 class UniversityModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     departments: List[UniversityDepartmentModel] = []
     semesters: List[UniversitySemesterModel] = []
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "AGU",
@@ -156,6 +176,8 @@ class UniversityAPIModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "_id": "c765c307-560c-47ab-b29e-0a1265eab860",
@@ -166,11 +188,13 @@ class UniversityAPIModel(BaseModel):
 
 
 class UpdateUniversityNameModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "AGU",

--- a/backend/apps/task/user_models.py
+++ b/backend/apps/task/user_models.py
@@ -6,6 +6,9 @@ from pydantic import BaseModel, Field, EmailStr
 from datetime import timedelta, datetime
 from passlib.context import CryptContext
 from jose import JWTError, jwt
+from bson import ObjectId
+
+from .PyObjectId import PyObjectId
 
 SECRET_KEY = "c8fc6e033c9801ca3c7d580dfd4756d691b96b3c8cc6e2313723eb49d7bc5384"
 ALGORITHM = "HS256"
@@ -16,7 +19,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
 class LessonModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     instructor: str = Field(...)
     absenceLimit: int = Field(..., ge=0)
@@ -25,6 +28,8 @@ class LessonModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "EE203",
@@ -75,10 +80,13 @@ class UpdateLessonModel(BaseModel):
 
 
 class AbsenceModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     absence: str = Field(...)
 
     class Config:
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "absence": "1,0,2",
@@ -87,7 +95,7 @@ class AbsenceModel(BaseModel):
 
 
 class UserSemesterModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
     startDate: datetime = Field(...)
     endDate: datetime = Field(...)
@@ -99,6 +107,8 @@ class UserSemesterModel(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "name": "2020-21 Spring",
@@ -163,13 +173,15 @@ class SemesterAPIModel(BaseModel):
 
 
 class UserModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     email: EmailStr = Field(...)
     password: str = Field(...)
     semesters: List[UserSemesterModel] = []
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "email": "hello@agu.edu.tr",
@@ -201,11 +213,13 @@ class UserAPIModel(BaseModel):
 
 
 class UpdatePasswordModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     password: str = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "password": "123456",
@@ -214,11 +228,13 @@ class UpdatePasswordModel(BaseModel):
 
 
 class UpdateSemesterModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     curSemesterID: str = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "curSemesterID": "c765c307-560c-47ab-b29e-0a1265eab860",
@@ -227,11 +243,13 @@ class UpdateSemesterModel(BaseModel):
 
 
 class UpdateEntranceYearModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     entranceYear: int = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "entranceYear": 2018,
@@ -240,11 +258,13 @@ class UpdateEntranceYearModel(BaseModel):
 
 
 class UpdateUniversityModel(BaseModel):
-    id: str = Field(default_factory=uuid.uuid4, alias="_id")
+    id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     curUniversityID: str = Field(...)
 
     class Config:
         allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
         schema_extra = {
             "example": {
                 "curUniversityID": "c765c307-560c-47ab-b29e-0a1265eab860",

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,6 @@ from apps.task.uni_cur_semester_routers import router as uni_cur_semester_router
 from apps.task.uni_cur_lesson_routers import router as uni_cur_lesson_router
 from apps.task.schedule_routers import router as schedule_router
 
-
 app = FastAPI()
 
 origins = ["*"]


### PR DESCRIPTION
MongoDB stores data as BSON. FastAPI encodes and decodes data as JSON strings. BSON has support for additional non-JSON-native data types, including ObjectId which can't be directly encoded as JSON. Because of this, we convert ObjectIds to strings before storing them as the _id.

As it can be seen from here https://www.mongodb.com/developer/quickstart/python-quickstart-fastapi/ we can create a PyObjectId class to create and validate ObjectIds for our system. We were using default_factory in IDs with UUID, instead of that now we can use PyObjectId.

A similar solution from the creator of fast API: https://github.com/tiangolo/fastapi/issues/68#issuecomment-497348481

closes #16 